### PR TITLE
Add callback to sync space with conditional to stall job completion

### DIFF
--- a/actions/pushToHCMShow.ts
+++ b/actions/pushToHCMShow.ts
@@ -19,8 +19,7 @@ export const pushToHcmShow = async (
 
   // Making a POST request to 'hcm.show' API to sync the space
   return await post({
-    // hostname: 'hcm.show',
-    hostname: '75b6-108-27-27-221.ngrok-free.app',
+    hostname: 'hcm.show',
     path: `/api/v1/sync-space`,
     body: { userId, spaceId, workflowType },
   });

--- a/actions/pushToHCMShow.ts
+++ b/actions/pushToHCMShow.ts
@@ -18,8 +18,9 @@ export const pushToHcmShow = async (
   const userId = await getUserIdFromSpace(spaceId);
 
   // Making a POST request to 'hcm.show' API to sync the space
-  await post({
-    hostname: 'hcm.show',
+  return await post({
+    // hostname: 'hcm.show',
+    hostname: '75b6-108-27-27-221.ngrok-free.app',
     path: `/api/v1/sync-space`,
     body: { userId, spaceId, workflowType },
   });

--- a/workflows/dynamic/index.ts
+++ b/workflows/dynamic/index.ts
@@ -226,9 +226,11 @@ export default function (listener) {
           progress: 10,
         });
 
+        let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          await pushToHcmShow(event, 'dynamic');
+          callback = await pushToHcmShow(event);
+
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));
         } catch (error) {
@@ -237,9 +239,11 @@ export default function (listener) {
           // Perform error handling, such as displaying an error message to the user or triggering a fallback behavior
         }
 
-        await api.jobs.complete(jobId, {
-          info: 'Data synced to the HCM.show app.',
-        });
+        if (callback === '{"success":true}') {
+          await api.jobs.complete(jobId, {
+            info: 'Data synced to the HCM.show app.',
+          });
+        }
       } catch (error) {
         console.error('Error:', error.stack);
 

--- a/workflows/dynamic/index.ts
+++ b/workflows/dynamic/index.ts
@@ -229,7 +229,7 @@ export default function (listener) {
         let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          callback = await pushToHcmShow(event, 'dynamic');
+          callback = JSON.parse(await pushToHcmShow(event, 'dynamic'));
 
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));
@@ -239,7 +239,7 @@ export default function (listener) {
           // Perform error handling, such as displaying an error message to the user or triggering a fallback behavior
         }
 
-        if (callback === '{"success":true}') {
+        if (callback.success) {
           await api.jobs.complete(jobId, {
             info: 'Data synced to the HCM.show app.',
           });

--- a/workflows/dynamic/index.ts
+++ b/workflows/dynamic/index.ts
@@ -229,7 +229,7 @@ export default function (listener) {
         let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          callback = await pushToHcmShow(event);
+          callback = await pushToHcmShow(event, 'dynamic');
 
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));

--- a/workflows/dynamic/index.ts
+++ b/workflows/dynamic/index.ts
@@ -229,7 +229,8 @@ export default function (listener) {
         let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          callback = JSON.parse(await pushToHcmShow(event, 'dynamic'));
+          const sendToShowSyncSpace = await pushToHcmShow(event, 'dynamic');
+          callback = JSON.parse(sendToShowSyncSpace);
 
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));

--- a/workflows/embedded/index.ts
+++ b/workflows/embedded/index.ts
@@ -230,7 +230,7 @@ export default function (listener) {
         let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          callback = await pushToHcmShow(event, 'embed');
+          callback = JSON.parse(await pushToHcmShow(event, 'embed'));
 
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));
@@ -240,7 +240,7 @@ export default function (listener) {
           // Perform error handling, such as displaying an error message to the user or triggering a fallback behavior
         }
 
-        if (callback === '{"success":true}') {
+        if (callback.success) {
           await api.jobs.complete(jobId, {
             info: 'Data synced to the HCM.show app.',
           });

--- a/workflows/embedded/index.ts
+++ b/workflows/embedded/index.ts
@@ -227,9 +227,11 @@ export default function (listener) {
           progress: 10,
         });
 
+        let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          await pushToHcmShow(event, 'embed');
+          callback = await pushToHcmShow(event);
+
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));
         } catch (error) {
@@ -238,9 +240,11 @@ export default function (listener) {
           // Perform error handling, such as displaying an error message to the user or triggering a fallback behavior
         }
 
-        await api.jobs.complete(jobId, {
-          info: 'Data synced to the HCM.show app.',
-        });
+        if (callback === '{"success":true}') {
+          await api.jobs.complete(jobId, {
+            info: 'Data synced to the HCM.show app.',
+          });
+        }
       } catch (error) {
         console.error('Error:', error.stack);
 

--- a/workflows/embedded/index.ts
+++ b/workflows/embedded/index.ts
@@ -230,7 +230,8 @@ export default function (listener) {
         let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          callback = JSON.parse(await pushToHcmShow(event, 'embed'));
+          const sendToShowSyncSpace = await pushToHcmShow(event, 'embed');
+          callback = JSON.parse(sendToShowSyncSpace);
 
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));

--- a/workflows/embedded/index.ts
+++ b/workflows/embedded/index.ts
@@ -230,7 +230,7 @@ export default function (listener) {
         let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          callback = await pushToHcmShow(event);
+          callback = await pushToHcmShow(event, 'embed');
 
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));

--- a/workflows/filefeed/index.ts
+++ b/workflows/filefeed/index.ts
@@ -285,7 +285,8 @@ export default function (listener) {
         let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          callback = JSON.parse(await pushToHcmShow(event));
+          const sendToShowSyncSpace = await pushToHcmShow(event);
+          callback = JSON.parse(sendToShowSyncSpace);
 
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));

--- a/workflows/filefeed/index.ts
+++ b/workflows/filefeed/index.ts
@@ -285,7 +285,7 @@ export default function (listener) {
         let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          callback = await pushToHcmShow(event);
+          callback = JSON.parse(await pushToHcmShow(event));
 
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));
@@ -295,7 +295,7 @@ export default function (listener) {
           // Perform error handling, such as displaying an error message to the user or triggering a fallback behavior
         }
 
-        if (callback === '{"success":true}') {
+        if (callback.success) {
           await api.jobs.complete(jobId, {
             info: 'Data synced to the HCM.show app.',
           });

--- a/workflows/filefeed/index.ts
+++ b/workflows/filefeed/index.ts
@@ -25,7 +25,7 @@ export default function (listener) {
     const topic = event.topic;
 
     post({
-      // hostname: 'hcm.show',
+      hostname: 'hcm.show',
       path: '/api/v1/sync-file-feed',
       body: { spaceId, topic },
     });

--- a/workflows/filefeed/index.ts
+++ b/workflows/filefeed/index.ts
@@ -25,7 +25,7 @@ export default function (listener) {
     const topic = event.topic;
 
     post({
-      hostname: 'hcm.show',
+      // hostname: 'hcm.show',
       path: '/api/v1/sync-file-feed',
       body: { spaceId, topic },
     });
@@ -282,9 +282,11 @@ export default function (listener) {
           progress: 10,
         });
 
+        let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          await pushToHcmShow(event);
+          callback = await pushToHcmShow(event);
+
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));
         } catch (error) {
@@ -293,9 +295,11 @@ export default function (listener) {
           // Perform error handling, such as displaying an error message to the user or triggering a fallback behavior
         }
 
-        await api.jobs.complete(jobId, {
-          info: 'Data synced to the HCM.show app.',
-        });
+        if (callback === '{"success":true}') {
+          await api.jobs.complete(jobId, {
+            info: 'Data synced to the HCM.show app.',
+          });
+        }
       } catch (error) {
         console.error('Error:', error.stack);
 

--- a/workflows/project/index.ts
+++ b/workflows/project/index.ts
@@ -363,9 +363,11 @@ export default function (listener) {
           progress: 10,
         });
 
+        let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          await pushToHcmShow(event);
+          callback = await pushToHcmShow(event);
+
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));
         } catch (error) {
@@ -374,9 +376,11 @@ export default function (listener) {
           // Perform error handling, such as displaying an error message to the user or triggering a fallback behavior
         }
 
-        await api.jobs.complete(jobId, {
-          info: 'Data synced to the HCM.show app.',
-        });
+        if (callback === '{"success":true}') {
+          await api.jobs.complete(jobId, {
+            info: 'Data synced to the HCM.show app.',
+          });
+        }
       } catch (error) {
         console.error('Error:', error.stack);
 

--- a/workflows/project/index.ts
+++ b/workflows/project/index.ts
@@ -366,7 +366,8 @@ export default function (listener) {
         let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          callback = JSON.parse(await pushToHcmShow(event));
+          const sendToShowSyncSpace = await pushToHcmShow(event);
+          callback = JSON.parse(sendToShowSyncSpace);
 
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));
@@ -376,11 +377,9 @@ export default function (listener) {
           // Perform error handling, such as displaying an error message to the user or triggering a fallback behavior
         }
 
-        if (callback.success) {
-          await api.jobs.complete(jobId, {
-            info: 'Data synced to the HCM.show app.',
-          });
-        }
+        await api.jobs.complete(jobId, {
+          info: 'Data synced to the HCM.show app.',
+        });
       } catch (error) {
         console.error('Error:', error.stack);
 

--- a/workflows/project/index.ts
+++ b/workflows/project/index.ts
@@ -376,9 +376,6 @@ export default function (listener) {
           // Perform error handling, such as displaying an error message to the user or triggering a fallback behavior
         }
 
-        console.log('Callback: ' + callback);
-        console.log('type: ' + typeof callback);
-
         if (callback.success) {
           await api.jobs.complete(jobId, {
             info: 'Data synced to the HCM.show app.',

--- a/workflows/project/index.ts
+++ b/workflows/project/index.ts
@@ -366,7 +366,7 @@ export default function (listener) {
         let callback;
         try {
           // Call the submit function with the event as an argument to push the data to HCM Show
-          callback = await pushToHcmShow(event);
+          callback = JSON.parse(await pushToHcmShow(event));
 
           // Log the action as a string to the console
           console.log('Action: ' + JSON.stringify(event?.payload?.operation));
@@ -376,7 +376,10 @@ export default function (listener) {
           // Perform error handling, such as displaying an error message to the user or triggering a fallback behavior
         }
 
-        if (callback === '{"success":true}') {
+        console.log('Callback: ' + callback);
+        console.log('type: ' + typeof callback);
+
+        if (callback.success) {
           await api.jobs.complete(jobId, {
             info: 'Data synced to the HCM.show app.',
           });


### PR DESCRIPTION
Why this PR?
- The api call to sync space does not complete before the success notification resulting in poor UX on the HCM show app where records are not upserted in time and not displayed in the respective resources page