### PR TITLE
In file feed event sync, use the job name if it exists, otherwise use…

### DIFF
--- a/common/hcm-show-api-service.ts
+++ b/common/hcm-show-api-service.ts
@@ -35,7 +35,11 @@ export class HcmShowApiService {
     console.log('Syncing filefeed in HCM.show.');
 
     const { spaceId } = event.context;
-    const topic = event.topic;
+    const topic = event.payload.job || event.topic;
+
+    if (!topic) {
+      return;
+    }
 
     return await post({
       apiBaseUrl: await this.getApiBaseUrl(event),


### PR DESCRIPTION
… the event name.