### PR TITLE
Add validation for job name length in jobValidations

### DIFF
--- a/recordHooks/jobs/jobValidations.js
+++ b/recordHooks/jobs/jobValidations.js
@@ -2,12 +2,19 @@ import { defaultInactiveAndWarnEffectiveDate } from './defaultInactiveAndWarnEff
 import { formatRecordDates } from '../../common/dateFormatting';
 import { generateJobCode } from './generateJobCode';
 import { validateBooleanFields } from '../../common/validateBooleanFields';
+import { validateJobNameLength } from './validateJobNameLength';
 
 export function jobValidations(record) {
   // Validate the input record parameter
   if (!record || typeof record !== 'object') {
     console.log('Invalid record input. Expecting a valid record object.');
     return record;
+  }
+
+  try {
+    validateJobNameLength(record); // Call the new function here
+  } catch (error) {
+    console.log('Error occurred during job name length validation:', error);
   }
 
   try {

--- a/recordHooks/jobs/jobValidations.js
+++ b/recordHooks/jobs/jobValidations.js
@@ -12,7 +12,7 @@ export function jobValidations(record) {
   }
 
   try {
-    validateJobNameLength(record); // Call the new function here
+    validateJobNameLength(record);
   } catch (error) {
     console.log('Error occurred during job name length validation:', error);
   }

--- a/recordHooks/jobs/validateJobNameLength.ts
+++ b/recordHooks/jobs/validateJobNameLength.ts
@@ -1,0 +1,23 @@
+// Function to validate the length of 'jobName' and add a warning if it exceeds 50 characters
+export const validateJobNameLength = (record) => {
+    try {
+      let jobName = record.get('jobName');
+      
+      // Check if 'jobName' is provided and if its length is greater than 50 characters
+      if (jobName && jobName.length > 50) {
+        record.addWarning(
+          'jobName',
+          `Job Name '${jobName}' exceeds 50 characters. Please shorten it.`
+        );
+      }
+    } catch (err) {
+      console.error(err);
+  
+      // Add an error message to the record if an error occurs
+      record.addError(
+        'validateJobNameLength',
+        `An error occurred: ${err.message}`
+      );
+    }
+  };
+  


### PR DESCRIPTION
This commit integrates a new validation function, `validateJobNameLength`, into the `jobValidations` function. This new function checks the length of the 'jobName' field in a record and adds a warning if the length exceeds 50 characters.

- Created `validateJobNameLength` to check 'jobName' field length.
- Integrated `validateJobNameLength` into `jobValidations`.
- Added error handling and logging for the new validation.