### PR TITLE
Update translationsPath to point to 'main' branch

### DIFF
--- a/common/flatfile-api-service.ts
+++ b/common/flatfile-api-service.ts
@@ -167,7 +167,7 @@ export class FlatfileApiService {
       primaryWorkbookId: workbookId,
       guestAuthentication: ['shared_link'],
       translationsPath:
-        'https://raw.githubusercontent.com/FlatFilers/Platform-Translations/kitchen-sink/locales/en/translation.json',
+        'https://raw.githubusercontent.com/FlatFilers/Platform-Translations/main/locales/en/translation.json',
       metadata: {
         userId,
         sidebarConfig: {


### PR DESCRIPTION
This change updates the `translationsPath` URL to fetch translations from the `main` branch instead of the `kitchen-sink` branch. This ensures that we're pulling the most up-to-date and stable translations for the platform.